### PR TITLE
Auto set config and db path

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -1,4 +1,8 @@
 # Server configurations
+#
+# DEVS:
+# IF DEFAULTS ARE NEEDED OR CHANGED, UPDATE `config/config.go`
+#
 server:
   enabled: true # enable the GRPC/HTTP/websocket server
   grpc_addr: 127.0.0.1:8881 #IP:port for GRPC


### PR DESCRIPTION
no longer is config needed to be in `config/config.yml` nor specified with a flag, but that is still respected. If not at `config/config.yml` and if not specified with flag, then it auto creates those defaults and drops them into `~/.imp/config.yml` which it will continue to read from for now on