### PR TITLE
Skip errors with lightning connection issues

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -400,7 +400,9 @@ func ConfigureWebsocketDIDComm(cfg config.Config, channel chan comm.IncomingDIDM
 func AddLightningNodes(cfg config.Config, lnm lightning.LightningManager) error {
 	lndNode, err := ConfigureLightningNodes(cfg)
 	if err != nil {
-		zap.L().Panic(err.Error())
+		zap.L().Error("Could not connect to lightning node, skipping lightning setup...",
+			zap.Error(err),
+		)
 	}
 	if lndNode == nil {
 		return nil


### PR DESCRIPTION
Fixes https://github.com/imperviousai/imp-daemon/issues/11 

Will proceed with the daemon even though lightning has issues. Good so that it doesn't shut down the daemon/browser, but it's going to be a little obscure as to whether or not lightning is working. Perhaps at some point we expand upon the `/status` endpoint so that it includes things like lightning status, ion, etc.