### PR TITLE
Algolia Bug Fixes

### DIFF
--- a/client/components/MainNavigation.jsx
+++ b/client/components/MainNavigation.jsx
@@ -41,7 +41,7 @@ import {
   WhatsappIcon,
 } from "react-share";
 import { createDid, resolveDid } from "../utils/id";
-import { useAddContact } from "../hooks/contacts";
+import { useAddContact, useFetchContacts } from "../hooks/contacts";
 import LightningToggle from "./LightingToggle";
 import { Autocomplete } from "./navigation/Autocomplete";
 import {
@@ -344,6 +344,7 @@ export default function MainNavigation({ children, currentPage }) {
   const [openAddContactForm, setOpenAddContactForm] = useState(false);
   const { data: myDid } = useFetchMyDid();
   const { mutate: addContact } = useAddContact();
+  const { data: contactsRes } = useFetchContacts();
 
   const isCurrent = (name) => currentPage === name;
 
@@ -378,6 +379,7 @@ export default function MainNavigation({ children, currentPage }) {
             Import contact{" "}
             <a
               href={`https://twitter.com/${item.twitterUsername}`}
+              target="_blank"
               className="text-md text-blue-400"
             >
               @{item.twitterUsername}

--- a/client/components/access/Onboard.jsx
+++ b/client/components/access/Onboard.jsx
@@ -303,7 +303,7 @@ function Onboard() {
         return relayRequest(relayEndpoint);
       })
       .then(() => {
-        console.log("Successfully registered to relay.", res.data);
+        console.log("Successfully registered to relay.");
         setIsLoading(false);
       })
       .catch((err) => {

--- a/client/components/contact/TwitterLink.jsx
+++ b/client/components/contact/TwitterLink.jsx
@@ -7,6 +7,7 @@ function TwitterLink({ contact, className }) {
       {twitterUsername && (
         <a
           className={className}
+          target="_blank"
           href={`https://twitter.com/${twitterUsername}`}
         >
           @{twitterUsername}

--- a/client/components/navigation/AutocompleteItem.jsx
+++ b/client/components/navigation/AutocompleteItem.jsx
@@ -1,9 +1,16 @@
-import { PlusIcon } from "@heroicons/react/outline";
+import { ArrowCircleDownIcon } from "@heroicons/react/outline";
 
 export function AutocompleteItem({ item, saveContactConfirm }) {
   return (
-    <div className="flex">
-      <div className="flex space-x-4 items-center w-full px-4">
+    <div className="flex space-x-4 items-center w-full px-4">
+      <button
+        type="button"
+        onClick={() => saveContactConfirm(item)}
+        className="inline-flex justify-self-end items-center rounded-full border border-transparent bg-blue-400 p-2 text-blue-400 shadow-sm hover:bg-blue-400 hover:text-white focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+      >
+        <ArrowCircleDownIcon className="h-8 w-8" aria-hidden="true" />
+      </button>
+      <div className="flex items-center space-x-4">
         <img
           className="inline-block h-8 w-8 rounded-full"
           src={item.avatarUrl}
@@ -12,6 +19,7 @@ export function AutocompleteItem({ item, saveContactConfirm }) {
         <div className="flex flex-col">
           <p className="text-lg text-gray-900">{item.name}</p>
           <a
+            target="_blank"
             href={`https://twitter.com/${item.twitterUsername}`}
             className="text-sm text-blue-400"
           >
@@ -19,15 +27,6 @@ export function AutocompleteItem({ item, saveContactConfirm }) {
           </a>
           <p className="text-sm text-gray-500">{item.shortFormDid}</p>
         </div>
-      </div>
-      <div className="flex items-center pr-2">
-        <button
-          type="button"
-          className="inline-flex items-center text-primary hover:bg-indigo-200 rounded-full"
-          onClick={() => saveContactConfirm(item)}
-        >
-          <PlusIcon className="h-6 w-6" aria-hidden="true" />
-        </button>
       </div>
     </div>
   );

--- a/client/components/settings/Identity.jsx
+++ b/client/components/settings/Identity.jsx
@@ -7,11 +7,14 @@ import { CheckCircleIcon } from "@heroicons/react/solid";
 import { LockClosedIcon } from "@heroicons/react/outline";
 import { useAuth0 } from "@auth0/auth0-react";
 import { useFetchMyDid } from "../../hooks/id";
+import { useAtom } from "jotai";
+import { publishedDidAtom, myDidLongFormDocumentAtom } from "../../stores/id";
 
 function Identity({ longFormDid }) {
-  const [publishedDid, setPublishedDid] = useState("");
+  const [publishedDid, setPublishedDid] = useAtom(publishedDidAtom);
   const { user } = useAuth0();
   const { data: myDid } = useFetchMyDid();
+  const [myDidLongFormDocument] = useAtom(myDidLongFormDocumentAtom);
 
   const { data, loading, error } = useQuery(GET_DID_BY_TWITTER, {
     variables: { twitterUsername: user?.nickname },
@@ -28,7 +31,7 @@ function Identity({ longFormDid }) {
   const [publishDid] = useMutation(gql(createDID), {
     variables: {
       input: {
-        longFormDid: longFormDid,
+        longFormDid: myDidLongFormDocument,
         shortFormDid: myDid?.id,
         twitterUsername: user?.nickname,
         avatarUrl: user?.picture,
@@ -43,7 +46,7 @@ function Identity({ longFormDid }) {
     variables: {
       input: {
         id: publishedDid?.id,
-        longFormDid: longFormDid,
+        longFormDid: myDidLongFormDocument,
         shortFormDid: myDid?.id,
         twitterUsername: user?.nickname,
         avatarUrl: user?.picture,

--- a/client/components/settings/IdentitySettings.jsx
+++ b/client/components/settings/IdentitySettings.jsx
@@ -9,7 +9,7 @@ import { myDidLongFormDocumentAtom } from "../../stores/id";
 const IdentitySettings = () => {
   const [longFormDid, setLongFormDid] = useState("");
   const { data: myDid } = useFetchMyDid();
-  const { isAuthenticated } = useAuth0();
+  const { isAuthenticated, user } = useAuth0();
   const [myDidLongFormDocument] = useAtom(myDidLongFormDocumentAtom);
 
   return (
@@ -23,18 +23,44 @@ const IdentitySettings = () => {
           </p>
         </div>
 
-        <div className="sm:col-span-6">
-          <label
-            htmlFor="photo"
-            className="block text-xl font-medium text-blue-gray-900"
-          >
-            Avatar
-          </label>
-          <p className="mt-1 text-md text-blue-gray-500">
-            Here is your avatar, you can rotate your avatar at any time.
-          </p>
-          <AvatarRotator />
-        </div>
+        {user ? (
+          <div className="sm:col-span-6">
+            <p
+              htmlFor="photo"
+              className="block text-xl font-medium text-blue-gray-900 pb-4"
+            >
+              Signed into Twitter:{" "}
+            </p>
+            <span>
+              <img
+                className="inline-block h-8 w-8 rounded-full"
+                src={user.picture}
+                alt=""
+              />
+              <a
+                href={`https://twitter.com/${user.nickname}`}
+                rel="noreferrer"
+                target="_blank"
+                className="text-blue-500 pl-2 text-xl"
+              >
+                @{user.nickname}
+              </a>
+            </span>
+          </div>
+        ) : (
+          <div className="sm:col-span-6">
+            <label
+              htmlFor="photo"
+              className="block text-xl font-medium text-blue-gray-900"
+            >
+              Avatar
+            </label>
+            <p className="mt-1 text-md text-blue-gray-500">
+              Here is your avatar, you can rotate your avatar at any time.
+            </p>
+            <AvatarRotator />
+          </div>
+        )}
 
         <div className="sm:col-span-6">
           <label

--- a/client/components/settings/IdentitySettings.jsx
+++ b/client/components/settings/IdentitySettings.jsx
@@ -1,26 +1,16 @@
 import { useState, useEffect } from "react";
 import { useAuth0 } from "@auth0/auth0-react";
-import { resolveDid } from "../../utils/id";
 import { useFetchMyDid } from "../../hooks/id";
 import Identity from "./Identity";
 import AvatarRotator from "../contact/AvatarRotator";
+import { useAtom } from "jotai";
+import { myDidLongFormDocumentAtom } from "../../stores/id";
 
 const IdentitySettings = () => {
   const [longFormDid, setLongFormDid] = useState("");
   const { data: myDid } = useFetchMyDid();
   const { isAuthenticated } = useAuth0();
-
-  useEffect(() => {
-    if (myDid) {
-      resolveDid(myDid.id)
-        .then((res) => {
-          setLongFormDid(res.data.longFormDid);
-        })
-        .catch((err) => {
-          console.log(err);
-        });
-    }
-  }, [myDid]);
+  const [myDidLongFormDocument] = useAtom(myDidLongFormDocumentAtom);
 
   return (
     <div className="max-w-3xl mx-auto py-10 px-4 sm:px-6 lg:py-12 lg:px-8">
@@ -64,7 +54,7 @@ const IdentitySettings = () => {
               disabled
               rows={4}
               className="block w-full p-4 border border-blue-gray-300 rounded-md shadow-sm sm:text-sm focus:ring-primary focus:border-blue-500"
-              defaultValue={longFormDid}
+              defaultValue={myDidLongFormDocument}
             />
           </div>
         </div>
@@ -81,7 +71,7 @@ const IdentitySettings = () => {
               Peers can search for your Twitter username in the Registry to find
               your latest Identity.
             </p>
-            <Identity longFormDid={longFormDid} />
+            <Identity />
           </div>
         )}
       </div>

--- a/client/stores/id.js
+++ b/client/stores/id.js
@@ -1,4 +1,10 @@
 import { atom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
 
 export const myDidDocumentAtom = atom();
 export const myDidLongFormDocumentAtom = atom();
+export const publishedDidAtom = atom("");
+export const currentRegistryUserAtom = atomWithStorage(
+  "currentRegisteryUser",
+  ""
+);

--- a/client/utils/contacts.js
+++ b/client/utils/contacts.js
@@ -156,7 +156,7 @@ export const getRandomAvatar = () => {
 
 export const GET_DID_BY_TWITTER = gql`
   query getDIDByTwitter($twitterUsername: String!) {
-    listDIDS(filter: { twitterUsername: { eq: $twitterUsername } }, limit: 1) {
+    listDIDS(filter: { twitterUsername: { eq: $twitterUsername } }) {
       items {
         avatarUrl
         id


### PR DESCRIPTION
This PR contains a few bug fixes around the recent contacts API and algolia search. 

- Upon first twitter login (first signin managed via local state), the user's DID is automatically published to the Contacts API. Users can delete or update this Did in Settings > Identity 
- If you are connected to twitter, the "This is your avatar" section in settings is replaced with your twitter profile to reinforce that you are signed in 
- Algolia dropdown items show a "more prominent" download button to import a contact. I tried to set the button to only appear if the contact wasn't already in your contacts but for some reason the algolia search bar wasn't honoring that logic. Super weird. Should revisit. 
- Clicking on links to a user's twitter profile opens in a new tab instead of redirecting them. 
- Fixed a small issue in the listDids graphql call that was allowing users to publish duplicate dids to the contacts api. 