### PR TITLE
Video Toggle + Bug Fixes

### DIFF
--- a/client/components/MainNavigation.jsx
+++ b/client/components/MainNavigation.jsx
@@ -56,6 +56,7 @@ import { AutocompleteItem } from "./navigation/AutocompleteItem";
 import { createDID } from "../src/graphql/mutations";
 import { GET_DID_BY_TWITTER } from "../utils/contacts";
 import { useLazyQuery, useMutation, gql } from "@apollo/client";
+import { PaperAirplaneIcon, PlusIcon } from "@heroicons/react/solid";
 
 const sidebarNavigation = [
   { name: "Dashboard", href: "/d/dashboard", icon: HomeIcon, current: false },
@@ -115,7 +116,7 @@ const ShareContactButton = ({ myDid }) => {
     <Menu as="div" className="relative inline-block text-left">
       <div>
         <Menu.Button className="order-0 inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-primary hover:bg-primary focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500 sm:order-1 sm:ml-3">
-          Share Contact
+          <PaperAirplaneIcon className="h-4 w-4 mr-1" /> Contact
         </Menu.Button>
       </div>
 
@@ -587,7 +588,7 @@ export default function MainNavigation({ children, currentPage }) {
                     {currentPage}
                   </h2>
                 </div>
-                <div className="bg-blue-100 w-1/2">
+                <div className="w-1/2">
                   <Autocomplete
                     placeholder="Search for user via Twitter username or contact name"
                     getSources={({ query }) => [
@@ -620,19 +621,19 @@ export default function MainNavigation({ children, currentPage }) {
                 </div>
 
                 <div className="ml-2 flex items-center space-x-4 sm:ml-6 sm:space-x-6">
-                  <button
+                  {/* <button
                     type="button"
                     className="ml-3 inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500 sm:order-0 sm:ml-0"
                   >
                     Share Browser
-                  </button>
+                  </button> */}
                   <ShareContactButton myDid={myDid} />
                   <button
                     type="button"
                     onClick={() => setOpenAddContactForm(true)}
                     className="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-primary hover:bg-primary focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500 sm:ml-3"
                   >
-                    Add Contact
+                    <PlusIcon className="h-4 w-4 mr-1" /> Contact
                   </button>
                   <TwitterConnect />
                 </div>

--- a/client/components/meeting/VideoCall.jsx
+++ b/client/components/meeting/VideoCall.jsx
@@ -3,7 +3,7 @@ import {
   UsersIcon,
   DesktopComputerIcon,
 } from "@heroicons/react/solid";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   BsFillMicMuteFill,
   BsFillMicFill,
@@ -19,6 +19,8 @@ import {
   currentVideoCallAtom,
   hasUnreadVideoMessagesAtom,
 } from "../../stores/peers";
+import { XCircleIcon } from "@heroicons/react/outline";
+import { toast } from "react-toastify";
 
 const Video = ({ peer }) => {
   const ref = useRef();
@@ -63,13 +65,8 @@ const VideoCall = ({ toggleMessaging, peers, id }) => {
   const [hasUnreadVideoMessages] = useAtom(hasUnreadVideoMessagesAtom);
 
   useEffect(() => {
-    navigator.mediaDevices
-      .getUserMedia({ audio: true, video: true })
-      .then((stream) => {
-        if (userVideo.current) userVideo.current.srcObject = stream;
-        setLocalStream(stream);
-      });
-  }, [setLocalStream]);
+    connectAudioandVideo();
+  }, [connectAudioandVideo]);
 
   useEffect(() => {
     if (peers.length === 0) {
@@ -82,7 +79,34 @@ const VideoCall = ({ toggleMessaging, peers, id }) => {
     }
   }, [peers, localStream]);
 
+  const connectAudioandVideo = useCallback(
+    () =>
+      new Promise((resolve, reject) => {
+        navigator.mediaDevices
+          .getUserMedia({ audio: true, video: true })
+          .then((stream) => {
+            if (userVideo.current) userVideo.current.srcObject = stream;
+            setLocalStream(stream);
+            resolve(stream);
+          })
+          .catch((err) => {
+            console.log("Unable to capture video stream: ", err);
+            toast.error("Unable to turn on audio and video. Please try again.");
+            reject(err);
+          });
+      })[setLocalStream]
+  );
+
+  const disconnectAudioandVideo = () => {
+    localStream?.getTracks().forEach((track) => {
+      track.stop();
+    });
+    setLocalStream();
+    userVideo.current.srcObject = undefined;
+  };
+
   const destroyCall = () => {
+    disconnectAudioandVideo();
     // Clear ephemeral messages as well
     setPeerMessages(
       peerMessages.filter((message) => message.networkId !== currentVideoCallId)
@@ -99,12 +123,12 @@ const VideoCall = ({ toggleMessaging, peers, id }) => {
           if (stream.getAudioTracks().length > 0) {
             stream.getAudioTracks().forEach((track) => {
               track.enabled = audioOn ? false : true;
-              setAudioOn(!audioOn);
             });
           }
         });
       }
     });
+    setAudioOn(!audioOn);
   };
 
   const toggleVideo = () => {
@@ -114,13 +138,12 @@ const VideoCall = ({ toggleMessaging, peers, id }) => {
           if (stream.getVideoTracks().length > 0) {
             stream.getVideoTracks().forEach((track) => {
               track.enabled = videoOn ? false : true;
-
-              setVideoOn(!videoOn);
             });
           }
         });
       }
     });
+    setVideoOn(!videoOn);
   };
 
   const replaceStream = (stream) => {
@@ -155,6 +178,53 @@ const VideoCall = ({ toggleMessaging, peers, id }) => {
     }
   };
 
+  const enableVideoConfirm = () => {
+    setOpenParticipants(true);
+    toast(
+      ({ closeToast }) => (
+        <div>
+          <p className="pb-1">Turn on camera and microphone?</p>
+          <p className="text-xs pb-2">
+            Do you want to turn on camera and microphone? This is a chat-only
+            invitation.{" "}
+          </p>
+          <div className="flex space-x-4">
+            <button
+              type="button"
+              onClick={() => {
+                connectAudioandVideo();
+                setOpenParticipants(true);
+                closeToast();
+              }}
+              className="inline-flex items-center px-2.5 py-1.5 border border-transparent text-xs font-medium rounded shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+            >
+              Connect Audio/Video
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                closeToast();
+                setOpenParticipants(true);
+              }}
+              className="inline-flex items-center px-2.5 py-1.5 border border-gray-300 shadow-sm text-xs font-medium rounded text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+            >
+              Continue
+            </button>
+          </div>
+        </div>
+      ),
+      { autoClose: false }
+    );
+  };
+
+  const handleParticipants = () => {
+    if (!localStream) {
+      enableVideoConfirm();
+      return;
+    }
+    setOpenParticipants(true);
+  };
+
   const getGridLayout = (count) => {
     if (count < 1) return "";
     if (count === 1) return "grid-cols-2";
@@ -176,9 +246,11 @@ const VideoCall = ({ toggleMessaging, peers, id }) => {
                 ref={userVideo}
                 autoPlay
               />
-              <div className="bg-gray-900 opacity-75 text-white rounded-md text-sm absolute bottom-0 left-0 px-4 m-2">
-                You
-              </div>
+              {localStream && (
+                <div className="bg-gray-900 opacity-75 text-white rounded-md text-sm absolute bottom-0 left-0 px-4 m-2">
+                  You
+                </div>
+              )}
             </div>
           </div>
           {peers.map((peer, i) => (
@@ -189,44 +261,74 @@ const VideoCall = ({ toggleMessaging, peers, id }) => {
       <div className="absolute bottom-0 w-11/12 mb-4 px-6">
         <div className="px-10 h-16 bg-black bg-opacity-40 inset-x-0 bottom-0 flex justify-between items-center rounded-lg">
           <div className="flex space-x-4">
-            {peers.length > 0 && (
-              <>
-                <button
-                  type="button"
-                  onClick={() => toggleMute()}
-                  className="flex flex-col items-center px-2 py-2 text-sm leading-4 font-medium rounded-md text-gray-50 bg-opacity-100 hover:bg-opacity-20 hover:bg-gray-100"
-                >
-                  {audioOn ? (
-                    <BsFillMicFill
-                      className="mb-2 h-6 w-6"
-                      aria-hidden="true"
-                    />
-                  ) : (
-                    <BsFillMicMuteFill
-                      className="mb-2 h-6 w-6"
-                      aria-hidden="true"
-                    />
+            <>
+              {localStream ? (
+                <>
+                  <button
+                    type="button"
+                    onClick={() => toggleMute()}
+                    className="flex flex-col items-center px-2 py-2 text-sm leading-4 font-medium rounded-md text-gray-50 bg-opacity-100 hover:bg-opacity-20 hover:bg-gray-100"
+                  >
+                    {audioOn ? (
+                      <BsFillMicFill
+                        className="mb-2 h-6 w-6"
+                        aria-hidden="true"
+                      />
+                    ) : (
+                      <BsFillMicMuteFill
+                        className="mb-2 h-6 w-6"
+                        aria-hidden="true"
+                      />
+                    )}
+                    {audioOn ? "Mute" : "Unmute"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => toggleVideo()}
+                    className="flex flex-col items-center px-2 py-2 text-sm leading-4 font-medium rounded-md text-gray-50 bg-opacity-100 hover:bg-opacity-20 hover:bg-gray-100"
+                  >
+                    {videoOn ? (
+                      <FaVideo className="mb-2 h-6 w-6" aria-hidden="true" />
+                    ) : (
+                      <FaVideoSlash
+                        className="mb-2 h-6 w-6"
+                        aria-hidden="true"
+                      />
+                    )}
+                    {videoOn ? "Stop Video" : "Start Video"}
+                  </button>
+                  {peers.length === 0 && (
+                    <button
+                      type="button"
+                      onClick={() => disconnectAudioandVideo()}
+                      className="flex flex-col items-center px-2 py-2 text-sm leading-4 font-medium rounded-md text-gray-50 bg-opacity-100 hover:bg-opacity-20 hover:bg-gray-100"
+                    >
+                      <XCircleIcon
+                        className="mb-2 h-6 w-6"
+                        aria-hidden="true"
+                      />
+                      Disconnect A/V
+                    </button>
                   )}
-                  {audioOn ? "Mute" : "Unmute"}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => toggleVideo()}
-                  className="flex flex-col items-center px-2 py-2 text-sm leading-4 font-medium rounded-md text-gray-50 bg-opacity-100 hover:bg-opacity-20 hover:bg-gray-100"
-                >
-                  {videoOn ? (
-                    <FaVideo className="mb-2 h-6 w-6" aria-hidden="true" />
-                  ) : (
-                    <FaVideoSlash className="mb-2 h-6 w-6" aria-hidden="true" />
+                </>
+              ) : (
+                <>
+                  {peers.length === 0 && (
+                    <button
+                      type="button"
+                      onClick={() => connectAudioandVideo()}
+                      className="flex flex-col items-center px-2 py-2 text-sm leading-4 font-medium rounded-md text-gray-50 bg-opacity-100 hover:bg-opacity-20 hover:bg-gray-100"
+                    >
+                      Connect Audio & Video
+                    </button>
                   )}
-                  {videoOn ? "Stop Video" : "Start Video"}
-                </button>
-              </>
-            )}
+                </>
+              )}
+            </>
           </div>
           <div className="flex space-x-4">
             <button
-              onClick={() => setOpenParticipants(true)}
+              onClick={handleParticipants}
               type="button"
               className="flex flex-col items-center px-2 py-2 text-sm leading-4 font-medium rounded-md text-gray-50 bg-opacity-100 hover:bg-opacity-20 hover:bg-gray-100"
             >
@@ -295,7 +397,7 @@ const VideoCall = ({ toggleMessaging, peers, id }) => {
             open={openParticipants}
             setOpen={setOpenParticipants}
             networkId={id}
-            localStream={localStream}
+            localStream={localStream || false}
             title="Invite Users to Meeting"
             subtitle={`Invite people to join this meeting.`}
             type="video-call-invitation"

--- a/client/components/navigation/Autocomplete.jsx
+++ b/client/components/navigation/Autocomplete.jsx
@@ -13,6 +13,7 @@ export function Autocomplete(props) {
     const search = autocomplete({
       container: containerRef.current,
       renderer: { createElement, Fragment, render },
+      detachedMediaQuery: "",
       ...props,
     });
 

--- a/client/components/navigation/AutocompleteItem.jsx
+++ b/client/components/navigation/AutocompleteItem.jsx
@@ -2,10 +2,14 @@ import { ArrowCircleDownIcon } from "@heroicons/react/outline";
 
 export function AutocompleteItem({ item, saveContactConfirm }) {
   return (
-    <div className="flex space-x-4 items-center w-full px-4">
+    <div
+      className="flex space-x-4 items-center w-full px-4 hover:bg-gray-100"
+      onClick={() => {
+        saveContactConfirm(item);
+      }}
+    >
       <button
         type="button"
-        onClick={() => saveContactConfirm(item)}
         className="inline-flex justify-self-end items-center rounded-full border border-transparent bg-blue-400 p-2 text-blue-400 shadow-sm hover:bg-blue-400 hover:text-white focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
       >
         <ArrowCircleDownIcon className="h-8 w-8" aria-hidden="true" />

--- a/client/hooks/messages.js
+++ b/client/hooks/messages.js
@@ -15,7 +15,8 @@ const getNotifications = (messages, myDid) => {
     .filter(
       (m) =>
         m.type === "https://didcomm.org/webrtc/1.0/sdp" &&
-        JSON.parse(m.data).body.content.signal?.type !== "answer"
+        JSON.parse(m.data).body.content.signal?.type !== "answer" &&
+        JSON.parse(m.data).from.split("?")[0] !== myDid.id
     )
     .map((m) => {
       return { ...m, data: JSON.parse(m.data) };

--- a/client/next.config.js
+++ b/client/next.config.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   reactStrictMode: true,
-
+  trailingSlash: true,
   typescript: {
     // !! WARN !!
     // Dangerously allow production builds to successfully complete even if


### PR DESCRIPTION
- Users can toggle video/audio on and off in the Meet section
- if an user is about to invite a user with a/v off, a prompt is displayed to allow the user to turn a/v on prior to invitations. otherwise if a/v is off then the call will just be a strictly ephemeral chat call
- main navigation buttons have a UI adjustment to include icons, so that the buttons don't get too big on higher zooms
- fixed the algolia autocomplete dropdown getting stuck, by moving to detached mode
- fixed UI refreshes on non / routes
- notifications was showing invitations that YOU sent, these have been filtered out