### PR TITLE
new file sharing modal to prevent users from breaking file transfer

### DIFF
--- a/client/components/FileUploader.jsx
+++ b/client/components/FileUploader.jsx
@@ -1,6 +1,5 @@
 import { useRef } from "react";
 import { PlusSmIcon } from "@heroicons/react/solid";
-import { v4 as uuidv4 } from "uuid";
 
 function FileUploader({ setFile, disabled }) {
   const hiddenFileInput = useRef(null);

--- a/client/components/MainNavigation.jsx
+++ b/client/components/MainNavigation.jsx
@@ -299,6 +299,8 @@ const TwitterConnect = () => {
     setAuth0Token,
     getDidsbyTwitter,
     publishDid,
+    currentRegistryUser?.nickname,
+    setCurrentRegistryUser,
   ]);
 
   let returnUrl = "";

--- a/client/components/meeting/ConversationFooter.jsx
+++ b/client/components/meeting/ConversationFooter.jsx
@@ -5,6 +5,7 @@ import FileUploader from "../FileUploader";
 import SelectedFileInput from "../SelectedFileInput";
 import useAutosizeTextArea from "../../components/useAutosizeTextArea";
 import { v4 as uuidv4 } from "uuid";
+import FileSharingModal from "./FileSharingModal";
 
 //  this needs to be reworked with flex grow
 const ConversationFooter = ({ sendPeerMessage, peers }) => {
@@ -19,6 +20,7 @@ const ConversationFooter = ({ sendPeerMessage, peers }) => {
   const [fileId, setFileId] = useState("");
   const [fileSize, setFileSize] = useState(0);
   const [chunkCount, setChunkCount] = useState(0);
+  const [openFileSharingModal, setOpenFileSharingModal] = useState(false);
 
   const textAreaRef = useRef(null);
 
@@ -32,6 +34,7 @@ const ConversationFooter = ({ sendPeerMessage, peers }) => {
 
   const startWebRTCFileTransfer = async () => {
     resetChunkProperties();
+    setOpenFileSharingModal(true);
     setFileId(uuidv4());
     const arrayBuffer = await fileInput.arrayBuffer();
     setFileSize(arrayBuffer.byteLength);
@@ -88,6 +91,7 @@ const ConversationFooter = ({ sendPeerMessage, peers }) => {
     sendPeerMessage({ name, type, size, id: fileId }, "file-transfer-done");
     setFileInput();
     setSendingFile();
+    setOpenFileSharingModal(false);
     setProgress(0);
   };
 
@@ -149,6 +153,11 @@ const ConversationFooter = ({ sendPeerMessage, peers }) => {
             />
           </button>
         </div>
+        <FileSharingModal
+          open={openFileSharingModal}
+          setOpen={setOpenFileSharingModal}
+          progress={progress}
+        />
       </div>
     </>
   );

--- a/client/components/meeting/FileSharingModal.jsx
+++ b/client/components/meeting/FileSharingModal.jsx
@@ -1,0 +1,91 @@
+import { Fragment } from "react";
+import { Dialog, Transition } from "@headlessui/react";
+import { TailSpin } from "react-loader-spinner";
+
+const FileSharingModal = ({ open, setOpen, progress, error }) => {
+  return (
+    <Transition.Root show={open} as={Fragment}>
+      <Dialog as="div" className="relative z-10" onClose={setOpen}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-gray-500 bg-opacity-25 transition-opacity" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 z-10 overflow-y-auto">
+          <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+              enterTo="opacity-100 translate-y-0 sm:scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 translate-y-0 sm:scale-100"
+              leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+            >
+              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white px-4 pt-5 pb-4 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-6">
+                <div>
+                  <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-gray-100">
+                    <TailSpin
+                      height="40"
+                      width="40"
+                      color="#312e81"
+                      ariaLabel="loading"
+                    />
+                  </div>
+                  <div className="mt-3 text-center sm:mt-5">
+                    <Dialog.Title
+                      as="h3"
+                      className="text-lg font-medium leading-6 text-gray-900"
+                    >
+                      Transferring file. Do not close.
+                    </Dialog.Title>
+                    <div className="mt-2">
+                      <p className="text-sm text-gray-500">
+                        Peer to peer file transfer in progress. It make take
+                        some time for the recipient to retrieve the file (est. 1
+                        min).
+                      </p>
+                      {progress > 0 && (
+                        <div className="flex items-center pt-2">
+                          <div className="w-full bg-gray-200 rounded-full dark:bg-gray-700 mx-20">
+                            <div
+                              className="bg-blue-600 text-xs font-medium text-blue-100 text-center p-0.5 leading-none rounded-full"
+                              style={{ width: `${Math.floor(progress)}%` }}
+                            >
+                              {" "}
+                              {Math.floor(progress)}%
+                            </div>
+                          </div>
+                        </div>
+                      )}
+                      {progress === 100 && (
+                        <div className="mt-5 sm:mt-6">
+                          <button
+                            type="button"
+                            className="inline-flex w-full justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-base font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 sm:text-sm"
+                            onClick={() => setOpen(false)}
+                          >
+                            File Transfer Complete!
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition.Root>
+  );
+};
+
+export default FileSharingModal;

--- a/client/components/meeting/VideoCall.jsx
+++ b/client/components/meeting/VideoCall.jsx
@@ -94,7 +94,8 @@ const VideoCall = ({ toggleMessaging, peers, id }) => {
             toast.error("Unable to turn on audio and video. Please try again.");
             reject(err);
           });
-      })[setLocalStream]
+      }),
+    [setLocalStream]
   );
 
   const disconnectAudioandVideo = () => {

--- a/client/package.json
+++ b/client/package.json
@@ -17,7 +17,7 @@
     "@aws-amplify/ui-react": "^3.5.1",
     "@bigheads/core": "^0.3.3",
     "@emoji-mart/data": "^1.0.2",
-    "@headlessui/react": "^1.4.1",
+    "@headlessui/react": "^1.7.3",
     "@heroicons/react": "^1.0.5",
     "@tailwindcss/typography": "^0.4.1",
     "algoliasearch": "^4.14.2",

--- a/client/pages/d/chat.jsx
+++ b/client/pages/d/chat.jsx
@@ -55,6 +55,7 @@ import FileDownload from "../../components/meeting/FileDownload";
 import useAutosizeTextArea from "../../components/useAutosizeTextArea";
 import ContactAvatar from "../../components/contact/ContactAvatar";
 import { getContactByDid, getContactsByMessage } from "../../utils/contacts";
+import FileSharingModal from "../../components/meeting/FileSharingModal";
 
 const isJSON = (msg) => {
   try {
@@ -531,6 +532,7 @@ const ConversationFooter = ({ sendBasicMessage, myDid }) => {
   const [fileId, setFileId] = useState("");
   const [fileSize, setFileSize] = useState(0);
   const [chunkCount, setChunkCount] = useState(0);
+  const [openFileSharingModal, setOpenFileSharingModal] = useState(false);
 
   const [lightningEnabled] = useAtom(lightningEnabledAtom);
   const [currentConversationPeer] = useAtom(currentConversationPeerAtom);
@@ -558,6 +560,7 @@ const ConversationFooter = ({ sendBasicMessage, myDid }) => {
 
   const startWebRTCFileTransfer = async () => {
     resetChunkProperties();
+    setOpenFileSharingModal(true);
     setFileId(uuidv4());
     const arrayBuffer = await fileInput.arrayBuffer();
     setFileSize(arrayBuffer.byteLength);
@@ -663,6 +666,7 @@ const ConversationFooter = ({ sendBasicMessage, myDid }) => {
     }
     setFileInput();
     setSendingFile();
+    setOpenFileSharingModal(false);
     setProgress(0);
   };
 
@@ -764,6 +768,11 @@ const ConversationFooter = ({ sendBasicMessage, myDid }) => {
             </button>
           </div>
         </div>
+        <FileSharingModal
+          open={openFileSharingModal}
+          setOpen={setOpenFileSharingModal}
+          progress={progress}
+        />
       </div>
     </div>
   );

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -4243,10 +4243,10 @@
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.2.1.tgz#9551142a1980503752536b5050fd99f4a7f13b17"
   integrity sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw==
 
-"@headlessui/react@^1.4.1":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.5.0.tgz#483b44ba2c8b8d4391e1d2c863898d7dd0cc0296"
-  integrity sha512-aaRnYxBb3MU2FNJf3Ut9RMTUqqU3as0aI1lQhgo2n9Fa67wRu14iOGqx93xB+uMNVfNwZ5B3y/Ndm7qZGuFeMQ==
+"@headlessui/react@^1.7.3":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.7.3.tgz#853c598ff47b37cdd192c5cbee890d9b610c3ec0"
+  integrity sha512-LGp06SrGv7BMaIQlTs8s2G06moqkI0cb0b8stgq7KZ3xcHdH3qMP+cRyV7qe5x4XEW/IGY48BW4fLesD6NQLng==
 
 "@heroicons/react@^1.0.5":
   version "1.0.6"


### PR DESCRIPTION
Add a modal to show that a file is being transferred from peer to peer. Users often click away to a different screen during this process, breaking the transfer process. 